### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities", "multimedia"]
 
 [dependencies]
 axum = { version = "0.5", features = ["multipart"] }
-base64 = "0"
+base64 = "0.13"
 ctrlc = { version = "3", features = ["termination"] }
 clap = { version = "3", features = ["derive"] }
 hyper = "0.14"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.