### PR TITLE
Windows missing QrSyncError Enum variant build fix

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -100,9 +100,8 @@ impl QrSyncHttp {
     fn find_public_ip(&self) -> QrSyncResult<String> {
         match &self.ip_address {
             Some(ip_address) => Ok(ip_address.to_string()),
-            None => Err(QrSyncError::new(
-                "On windows the command-line option --ip-address is mandatory",
-                Some("ip-discovery"),
+            None => Err(QrSyncError::Error(
+                "On windows the command-line option --ip-address is mandatory".into()
             )),
         }
     }


### PR DESCRIPTION
Got " variant or associated item not found in `QrSyncError`" error when building project on **Windows** while it was working fine on **linux** so I'm pushing this simple fix for this cool project :) .

**error in console**
![image](https://github.com/crisidev/qrsync/assets/32032778/3282d899-9619-4d2f-bf85-00d69af73bf5)

**error in editor**
![image](https://github.com/crisidev/qrsync/assets/32032778/8ac872f4-5188-4f03-bf73-02cb46a584cd)
